### PR TITLE
Add path option

### DIFF
--- a/lib/gremlin_client/connection.rb
+++ b/lib/gremlin_client/connection.rb
@@ -33,6 +33,7 @@ module GremlinClient
     def initialize(
       host: 'localhost',
       port: 8182,
+      path: '/',
       connection_timeout: 1,
       timeout: 10,
       gremlin_script_path: '.',
@@ -40,6 +41,7 @@ module GremlinClient
     )
       @host = host
       @port = port
+      @path = path
       @connection_timeout = connection_timeout
       @timeout = timeout
       @gremlin_script_path = gremlin_script_path
@@ -51,7 +53,7 @@ module GremlinClient
     # creates a new connection object
     def connect
       gremlin = self
-      WebSocket::Client::Simple.connect("ws://#{@host}:#{@port}/") do |ws|
+      WebSocket::Client::Simple.connect("ws://#{@host}:#{@port}#{@path}") do |ws|
         @ws = ws
 
         @ws.on :message do |msg|

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe :connection do
     end
 
     it :websocket do
-      expect(WebSocket::Client::Simple).to receive(:connect).with('ws://SERVER_A:123/')
-      conn = GremlinClient::Connection.new(host: :SERVER_A, port: 123)
+      expect(WebSocket::Client::Simple).to receive(:connect).with('ws://SERVER_A:123/path/to/gremlin')
+      conn = GremlinClient::Connection.new(host: :SERVER_A, port: 123, path: '/path/to/gremlin')
     end
 
     it :gremlin_script_path do


### PR DESCRIPTION
### What

Enable to set path of gremlin websocket endpoint uri.

### Why

I'm using [Amazon Neptune](https://aws.amazon.com/neptune/) and its gremlin endpoint is http://your-neptune-endpoint:8182/gremlin

### Ref

- [Gremlin HTTP and WebSocket API - Amazon Neptune](https://docs.aws.amazon.com/ja_jp/neptune/latest/userguide/gremlin-api-reference.html)