### PR TITLE
Add 'path' parameter for websocket URL and default to 'gremlin'

### DIFF
--- a/lib/gremlin_client/connection.rb
+++ b/lib/gremlin_client/connection.rb
@@ -33,6 +33,7 @@ module GremlinClient
     def initialize(
       host: 'localhost',
       port: 8182,
+      path: 'gremlin',
       connection_timeout: 1,
       timeout: 10,
       gremlin_script_path: '.',
@@ -40,6 +41,7 @@ module GremlinClient
     )
       @host = host
       @port = port
+      @path = path
       @connection_timeout = connection_timeout
       @timeout = timeout
       @gremlin_script_path = gremlin_script_path
@@ -51,7 +53,7 @@ module GremlinClient
     # creates a new connection object
     def connect
       gremlin = self
-      WebSocket::Client::Simple.connect("ws://#{@host}:#{@port}/") do |ws|
+      WebSocket::Client::Simple.connect("ws://#{@host}:#{@port}/#{@path}") do |ws|
         @ws = ws
 
         @ws.on :message do |msg|

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe :connection do
 
   describe :initialize do
     it :websocket do
-      expect(WebSocket::Client::Simple).to receive(:connect).with('ws://localhost:8182/')
+      expect(WebSocket::Client::Simple).to receive(:connect).with('ws://localhost:8182/gremlin')
       conn = GremlinClient::Connection.new
     end
 
     it :websocket do
-      expect(WebSocket::Client::Simple).to receive(:connect).with('ws://SERVER_A:123/')
+      expect(WebSocket::Client::Simple).to receive(:connect).with('ws://SERVER_A:123/gremlin')
       conn = GremlinClient::Connection.new(host: :SERVER_A, port: 123)
     end
 


### PR DESCRIPTION
The default websocket URL for the [gremlin server](http://tinkerpop.apache.org/downloads.html) is `ws://localhost:8182/gremlin`.

This PR adds a `path` parameter to the `GremlinClient::Connection` constructor that defaults to `gremlin` and interpolates it into the websocket URL.