### PR TITLE
Fix receive_error call scope

### DIFF
--- a/lib/gremlin_client/connection.rb
+++ b/lib/gremlin_client/connection.rb
@@ -61,7 +61,7 @@ module GremlinClient
         end
 
         @ws.on :error do |e|
-          receive_error(e)
+          gremlin.receive_error(e)
         end
       end
     end


### PR DESCRIPTION
Call enthod in GremlinClient::Connection instead of WebSocket::Client::Simple::Client

Fixes "undefined method `receive_error' for #<WebSocket::Client::Simple::Client:0x00007f2779500d78> (NoMethodError)"